### PR TITLE
feat: Created an automated version via Github Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/sign-the-terms.yml
+++ b/.github/ISSUE_TEMPLATE/sign-the-terms.yml
@@ -1,0 +1,20 @@
+name: 'Firmar el acuerdo'
+description: 'Sigue los pasos para formar parte del equipo de ingeniería de JavaScript Chile.'
+body:
+  - type: markdown
+    attributes:
+      value: Agradecemos enormemente tu interés en formar parte de nuestro equipo de ingeniería. Para completar tu aplicación, debes haber leído y comprometerte a cumplir nuestro [Código de Conducta](https://github.com/jsconfcl/code_of_conduct) y aceptar nuestros [Principios de Ingeniería](https://eng.jschile.org/JSChile-Principios-de-Ingenier-a-7c87246f2dac49f38b42dd509238f9fb). Si aún no lo has hecho, por favor, hazlo antes de continuar.
+
+  - type: markdown
+    attributes:
+      value: Para terminar tu aplicación, por favor, ingresa tu nombre y apellido en el título de esta solicitud. Ten en cuenta que el uso de mayúsculas se preservará en la firma, además, esta quedará inmortalizada en el README, pudiéndo ser modificada solo con la asistencia de un administrador.
+
+  - type: checkboxes
+    id: agreement
+    attributes:
+      label: He leído y me comprometo a
+      options:
+        - label: Seguir y hacer cumplir el Código de Conducta de JavaScript Chile.
+          required: true
+        - label: Guiarme por los Principios de Ingeniería de JavaScript Chile.
+          required: true

--- a/.github/workflows/accept_signature.yml
+++ b/.github/workflows/accept_signature.yml
@@ -1,0 +1,37 @@
+name: Accept new signature
+
+concurrency:
+  group: one-at-a-time
+  cancel-in-progress: false
+
+on:
+  issues:
+    types: [closed]
+    
+permissions:
+  contents: write
+
+jobs:
+  add-signature:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != github.event.issue.user.login }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Add the signment of user
+        if: ${{ github.actor != 'github-actions[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          USER: ${{ github.event.issue.user.login }}
+          NAME: ${{ github.event.issue.title }}
+          ID: ${{ github.event.issue.user.id }}
+        run: |
+          sed -i 's;### Con 💛 JSCL.Eng;'"| $NAME | [@$USER](https://github.com/$USER) |"';' ./README.md
+          echo "### Con 💛 JSCL.Eng" >> ./README.md
+          git config --global user.email "$ID+$USER@users.noreply.github.com"
+          git config --global user.name "$USER"
+          git add .
+          git commit -m "feat: Acuerdo firmado por $USER en la issue #$NUMBER"
+          git push origin main
+          fi

--- a/.github/workflows/signature_listener.yml
+++ b/.github/workflows/signature_listener.yml
@@ -1,0 +1,31 @@
+name: Issue filtering
+
+concurrency:
+  group: one-at-a-time
+  cancel-in-progress: false
+
+on:
+  issues:
+    types: [opened]
+    
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  add-signature:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Auto-close known signatures
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          USER: ${{ github.event.issue.user.login }}
+        run: |
+          if grep -qi "@$USER" ./README.md; then
+          gh issue close --comment "El usuario $USER ya ha firmado. No se considerará esta solicitud" "$NUMBER"
+          else
+          gh issue comment "$NUMBER" --body "Se ha recibido la firma exitosamente. Esperando a un mantenedor..."
+          fi

--- a/README.md
+++ b/README.md
@@ -2,36 +2,23 @@
 
 Este repo es nuestro registro de quienes pertenecen al Equipo de Ingenería de JavaScript Chile.
 
-Quienes firman, han leido y están de acuerdo con lo definido nuestros [Engineering Tennants](https://eng.jschile.org/JSChile-Principios-de-Ingenier-a-7c87246f2dac49f38b42dd509238f9fb), se compromenten a seguir y hacer cumplir nuestro [código de conducta](https://github.com/jsconfcl/code_of_conduct), a respetar la privacidad de usuarios y hacer buen uso de los datos e información a los que tengan accesso.
+Quienes firman, han leido y están de acuerdo con lo definido nuestros [Principios de Ingeniería](https://eng.jschile.org/JSChile-Principios-de-Ingenier-a-7c87246f2dac49f38b42dd509238f9fb), se compromenten a seguir y hacer cumplir nuestro [código de conducta](https://github.com/jsconfcl/code_of_conduct), a respetar la privacidad de usuarios y hacer buen uso de los datos e información a los que tengan acceso.
 
 
 ## Engineering Team
 
 | **Nombre** | **Github Username** |
-| ------------------------------------------- | -------------------------------------------------------------------- |
-| Felipe Torres                               | [@fforres](https://github.com/fforres)                               |
-| José LEzama GOnzález                        | [@joseglego](https://github.com/joseglego)                           |
-| Benjamin Perez                              | [@benjvvp](https://github.com/benjvvp)                               |
-| Rodrigo Bustamante                          | [@rodrigobustamante](https://github.com/rodrigobustamante)           |
-| Vicente González                            | [@Vicente-G](https://github.com/Vicente-G)                           |
-| Pillippa Pérez Pons                         | [@Pillin](https://github.com/Pillin)                                 |
-| Cecilia Geraldo                             | [@ceciliaGeraldo](https://github.com/ceciliaGeraldo)                 |
-| Claudio Álvarez Rivera                      | [@ottoalvarez](https://github.com/ottoalvarez)                       |
-| Leslie Herrera                              | [@Dereemii](https://github.com/Dereemii)                             |
-| Ignacio Guzmán                              | [@TextC0de](https://github.com/TextC0de)                             |
-| Alex Elgueta                                | [@AlexElguetaDev](https://github.com/AlexElguetaDev)                 |
-| Simón Muñoz Saavedra                        | [@Sabmus](https://github.com/Sabmus)                                 |
-
-<!-- Este es un placeholder para una nueva entrada, sientente libre de copiarlo y usarlo en la tabla superior. -->
-<!--
-
-|                                             | [x](xxxxx)                                        |  
-
--->
-
-
-----
-
-Con 💛
-
-### JSCL.Eng
+| ---------- | ------------------- |
+| Felipe Torres | [@fforres](https://github.com/fforres) |
+| José LEzama GOnzález | [@joseglego](https://github.com/joseglego) |
+| Benjamin Perez | [@benjvvp](https://github.com/benjvvp) |
+| Rodrigo Bustamante | [@rodrigobustamante](https://github.com/rodrigobustamante) |
+| Vicente González | [@Vicente-G](https://github.com/Vicente-G) |
+| Pillippa Pérez Pons | [@Pillin](https://github.com/Pillin) |
+| Cecilia Geraldo | [@ceciliaGeraldo](https://github.com/ceciliaGeraldo) |
+| Claudio Álvarez Rivera | [@ottoalvarez](https://github.com/ottoalvarez) |
+| Leslie Herrera | [@Dereemii](https://github.com/Dereemii) |
+| Ignacio Guzmán | [@TextC0de](https://github.com/TextC0de) |
+| Alex Elgueta | [@AlexElguetaDev](https://github.com/AlexElguetaDev) |
+| Simón Muñoz Saavedra | [@Sabmus](https://github.com/Sabmus) |
+### Con 💛 JSCL.Eng

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Este repo es nuestro registro de quienes pertenecen al Equipo de Ingenería de J
 
 Quienes firman, han leido y están de acuerdo con lo definido nuestros [Principios de Ingeniería](https://eng.jschile.org/JSChile-Principios-de-Ingenier-a-7c87246f2dac49f38b42dd509238f9fb), se compromenten a seguir y hacer cumplir nuestro [código de conducta](https://github.com/jsconfcl/code_of_conduct), a respetar la privacidad de usuarios y hacer buen uso de los datos e información a los que tengan acceso.
 
+[![Firma](https://img.shields.io/badge/firma_aqui!-f7df1e?style=for-the-badge&logo=buddy&logoColor=000000)](https://github.com/jsconfcl/engineering-team-covenant/issues/new?template=sign-the-terms.yml)
 
 ## Engineering Team
 


### PR DESCRIPTION
## Por qué hacer este cambio?
La idea de tener a un admin pendiente de los PRs de este repo 24/7 no suena bien, y la consecuencia que esto tiene, es que solo se podrá hacer una firma a la vez, de lo contrario se generarán conflictos con todos los PRs que no hayan sido cerrados. Esto no es del todo crítico, pero si es algo molesto

## Cómo se arreglaría entonces?
Con este PR, la firma en el README se deberá hacer con una Github Issue, para facilitar las cosas, en el README se agregó un shortcut. La firma consiste en escribir el nombre en el titulo y aceptar con las checkboxes que se han leído los documentos requeridos. Cuando esa Issue haya sido abierta, mediante Github Actions se hace el cambio al README y se cierra la Issue.

## Disclaimer
Adicionalmente, si algo no es correcto o genera conflictos con lo que se quiere lograr con este repositorio, se aceptan sugerencias via comentarios y contribuciones al fork.